### PR TITLE
Fix regression in upstart init.d link name

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -494,8 +494,8 @@ class FPM::Package::Deb < FPM::Package
 
     attributes.fetch(:deb_upstart_list, []).each do |upstart|
       name = File.basename(upstart, ".upstart")
-      name = "#{name}.conf" if !(name =~ /\.conf$/)
-      dest_upstart = staging_path("etc/init/#{name}")
+      confname = (name =~ /\.conf$/) ? name : "#{name}.conf"
+      dest_upstart = staging_path("etc/init/#{confname}")
       mkdir_p(File.dirname(dest_upstart))
       FileUtils.cp(upstart, dest_upstart)
       File.chmod(0644, dest_upstart)


### PR DESCRIPTION
Fix a regression causing the /etc/init.d/ link created for upstart jobs to incorrectly receive a .conf extension
